### PR TITLE
fix bugs in IP,nslookup and process, add listenTo feature

### DIFF
--- a/Arduino_sample/MT7681/MT7681.cpp
+++ b/Arduino_sample/MT7681/MT7681.cpp
@@ -4,192 +4,188 @@
 #include <MT7681.h>
 static int base64_encode_len(int len)
 {
-  return ((len+2)/3)*4;
+    return ((len+2)/3)*4;
 }
 
 static uint8_t base64_enc_map(uint8_t n)
 {
-  if(n < 26)
-  return 'A'+n;
-  if(n < 52)
-  return 'a'+(n-26);
-  if(n < 62)
-  return '0'+(n-52);
-  return n == 62 ? '+' : '/';
+    if(n < 26)
+        return 'A'+n;
+    if(n < 52)
+        return 'a'+(n-26);
+    if(n < 62)
+        return '0'+(n-52);
+    return n == 62 ? '+' : '/';
 }
 
 static void base64_encode(const uint8_t* src, int len, uint8_t* dest)
 {
-  uint32_t w;
-  uint8_t t;
-  while(len >= 3)
-  {
-    w = ((uint32_t)src[0])<<16 | ((uint32_t)src[1])<<8 | ((uint32_t)src[2]);
+    uint32_t w;
+    uint8_t t;
+    while(len >= 3)
+    {
+        w = ((uint32_t)src[0])<<16 | ((uint32_t)src[1])<<8 | ((uint32_t)src[2]);
 
-    dest[0] = base64_enc_map((w>>18)&0x3F);
-    dest[1] = base64_enc_map((w>>12)&0x3F);
-    dest[2] = base64_enc_map((w>>6)&0x3F);
-    dest[3] = base64_enc_map((w)&0x3F);
+        dest[0] = base64_enc_map((w>>18)&0x3F);
+        dest[1] = base64_enc_map((w>>12)&0x3F);
+        dest[2] = base64_enc_map((w>>6)&0x3F);
+        dest[3] = base64_enc_map((w)&0x3F);
 
-    len-=3;
-    src+=3;
-    dest+=4;
-  }
-  if(!len)
-  return;
+        len-=3;
+        src+=3;
+        dest+=4;
+    }
+    if(!len)
+        return;
 
-  if(len == 2)
-  {
-    w = ((uint32_t)src[0])<<8 | ((uint32_t)src[1]);
+    if(len == 2)
+    {
+        w = ((uint32_t)src[0])<<8 | ((uint32_t)src[1]);
 
-    dest[0] = base64_enc_map((w>>10)&0x3F);
-    dest[1] = base64_enc_map((w>>4)&0x3F);
-    dest[2] = base64_enc_map((w&0x0F)<<2);
-    dest[3] = '=';
-  }
-  else
-  {
-    w = src[0];
+        dest[0] = base64_enc_map((w>>10)&0x3F);
+        dest[1] = base64_enc_map((w>>4)&0x3F);
+        dest[2] = base64_enc_map((w&0x0F)<<2);
+        dest[3] = '=';
+    }
+    else
+    {
+        w = src[0];
 
-    dest[0] = base64_enc_map((w>>2)&0x3F);
-    dest[1] = base64_enc_map((w&0x03)<<4);
-    dest[2] = '=';
-    dest[3] = '=';
-  }
+        dest[0] = base64_enc_map((w>>2)&0x3F);
+        dest[1] = base64_enc_map((w&0x03)<<4);
+        dest[2] = '=';
+        dest[3] = '=';
+    }
 }
 
 static int base64_decode_len(int len)
 {
-  return ((len+3)/4)*3;
+    return ((len+3)/4)*3;
 }
 
 static uint32_t base64_dec_map(uint8_t n)
 {
-  if(n >= 'A' && n <= 'Z')
-  return n - 'A';
-  if(n >= 'a' && n <= 'z')
-  return n - 'a' + 26;
-  if(n >= '0' && n <= '9')
-  return n - '0' + 52;
-  return n == '+' ? 62 : 63;
+    if(n >= 'A' && n <= 'Z')
+        return n - 'A';
+    if(n >= 'a' && n <= 'z')
+        return n - 'a' + 26;
+    if(n >= '0' && n <= '9')
+        return n - '0' + 52;
+    return n == '+' ? 62 : 63;
 }
 
 static int base64_decode(const uint8_t* src, int len, uint8_t* dest)
 {
-  uint32_t w;
-  uint8_t t;
-  int result = 0;
+    uint32_t w;
+    uint8_t t;
+    int result = 0;
 
     // remove trailing =
     while(src[len-1] == '=')
-    len--;
+        len--;
 
     while(len >= 4)
     {
-      w = (base64_dec_map(src[0]) << 18) |
-      (base64_dec_map(src[1]) << 12) |
-      (base64_dec_map(src[2]) << 6) |
-      base64_dec_map(src[3]);
+        w = (base64_dec_map(src[0]) << 18) |
+            (base64_dec_map(src[1]) << 12) |
+            (base64_dec_map(src[2]) << 6) |
+            base64_dec_map(src[3]);
 
-      dest[0] = (w>>16)&0xFF;
-      dest[1] = (w>>8)&0xFF;
-      dest[2] = (w)&0xFF;
+        dest[0] = (w>>16)&0xFF;
+        dest[1] = (w>>8)&0xFF;
+        dest[2] = (w)&0xFF;
 
-      len-=4;
-      src+=4;
-      dest+=3;
-      result+=3;
+        len-=4;
+        src+=4;
+        dest+=3;
+        result+=3;
     }
     if(!len)
-    return result;
+        return result;
 
     if(len == 3)
     {
-      w = (base64_dec_map(src[0]) << 18) |
-      (base64_dec_map(src[1]) << 12) |
-      (base64_dec_map(src[2]) << 6) |
-      0;
+        w = (base64_dec_map(src[0]) << 18) |
+            (base64_dec_map(src[1]) << 12) |
+            (base64_dec_map(src[2]) << 6) |
+            0;
 
-      dest[0] = (w>>16)&0xFF;
-      dest[1] = (w>>8)&0xFF;
-      result+=2;
+        dest[0] = (w>>16)&0xFF;
+        dest[1] = (w>>8)&0xFF;
+        result+=2;
     }
     else if(len == 2)
     {
-      w = (base64_dec_map(src[0]) << 18) |
-      (base64_dec_map(src[1]) << 12) |
-      0;
+        w = (base64_dec_map(src[0]) << 18) |
+            (base64_dec_map(src[1]) << 12) |
+            0;
 
-      dest[0] = (w>>16)&0xFF;
-      result+=1;
+        dest[0] = (w>>16)&0xFF;
+        result+=1;
     }
     else
     {
         // should not happen.
-      }
-      return result;
     }
+    return result;
+}
 
 
-    
 
-    LC7681Wifi::LC7681Wifi(Stream *s, Stream* l):
-    m_lport(0)
-    {
-      m_stream = s;
-      m_log = l;
-      m_bufferPos = 0;
+
+LC7681Wifi::LC7681Wifi(Stream *s, Stream* l):
+m_lport(0)
+{
+    m_stream = s;
+    m_log = l;
+    m_bufferPos = 0;
+}
+
+void LC7681Wifi::begin()
+{
+
+}
+
+bool LC7681Wifi::connectAP(const char* ssid, const char* key,int type)
+{
+    String str = F("AT+WCAP=");
+    str += String(ssid);
+    str += ",";
+    str += String(key);
+    str += ",";
+    str += String(type);
+    m_stream->println(str);
+    if(m_log){
+        m_log->print("[Send cmd]");
+        m_log->println(str);
     }
-
-    void LC7681Wifi::begin()
-    {
-      
+    //      str = String("+WCAP:") + String(ssid);
+    str = String("+WCAP:");
+    if(m_log){
+        m_log->print("[Wait for]");
+        m_log->println(str);
     }
-    
-    bool LC7681Wifi::connectAP(const char* ssid, const char* key,int type)
+    String result = _wait_for(str.c_str(),160);
+    //      Serial.println(str.c_str());
+    //      Serial.println(result);
+    if(strlen(result.c_str()) != 0)
     {
-      String str = F("AT+WCAP=");
-      str += String(ssid);
-      str += ",";
-      str += String(key);
-      str += ",";
-      str += String(type);
-       m_stream->println(str);
-/*
-      m_stream->print(F("AT+WCAP="));
-      m_stream->print(ssid);
-      m_stream->print(F(","));
-      m_stream->print(key);
-      m_stream->print(F(","));
-      m_stream->println(type);
-     */ 
-      if(m_log){
-      m_log->print("[Send cmd]");
-      m_log->println(str);
-      }
-      str = String("+WCAP:") + String(ssid);
-      if(m_log){
-      m_log->print("[Wait for]");
-      m_log->println(str);
-      }
-      if(_wait_for(str.c_str(),160) != 0)
-      {
         return true;
-      }
-  
-      return false;
     }
-    
-    IPAddress LC7681Wifi::s2ip(const char* str)
-    {
-      uint32_t ip[4];
-      String ipaddress(0);
-      int count = 0;
+
+    return false; 
+}
+
+IPAddress LC7681Wifi::s2ip(const char* str)
+{
+    uint32_t ip[4];
+    String ipaddress(0);
+    int count = 0;
 
     //  //Serial.print("INTPUT IP:");
     //  //Serial.print(str);
-     // //Serial.print(" Size:");
-     // //Serial.println(strlen(str));
+    // //Serial.print(" Size:");
+    // //Serial.println(strlen(str));
     /*  for (int i = 0; i <= strlen(str); ++i)
       { 
       //  //Serial.print(i);
@@ -211,54 +207,74 @@ static int base64_decode(const uint8_t* src, int len, uint8_t* dest)
         }
       }
       */
-      sscanf(str, "%d.%d.%d.%d", ip, ip+1, ip+2, ip+3);
-      return IPAddress(ip[0], ip[1], ip[2], ip[3]);
-    }
+    sscanf(str, "%d.%d.%d.%d", ip, ip+1, ip+2, ip+3);
+    return IPAddress(ip[0], ip[1], ip[2], ip[3]);
+}
+
+IPAddress LC7681Wifi::IP()
+{
+    String result, ips;
+    IPAddress ipAddr;
+
     
-    IPAddress LC7681Wifi::IP()
-    {
-      String result, ips;
-      m_stream->println(F("AT+WQIP?"));
-      result = _wait_for("+WQIP:", 5);
-      if(result.length() == 0)
-      return IPAddress();
-      ips = result.substring(6, result.indexOf(',', 6));
-      return s2ip(ips.c_str());
-    }
-    
-    IPAddress LC7681Wifi::nslookup(const char* server)
-    {
-      String result, ips;
-      
-      result = F("AT+WDNL=");
-      result += server;
-      m_stream->println(result);
-      ////Serial.println(result);
-      result = _wait_for("+WDNL:", 5);
-      if(result.length() == 0)
-      return IPAddress();
-      
-      ips = result.substring(result.lastIndexOf(',')+1);
-      return s2ip(ips.c_str());
+    while(true) {
+        m_stream->println(F("AT+WQIP?"));
+        result = _wait_for("+WQIP:", 5);
+        if(result.length() != 0) {
+            ips = result.substring(6, result.indexOf(',', 6));
+            ipAddr = s2ip(ips.c_str());
+            if(ipAddr[0] != 0 && ipAddr[1] != 0 && ipAddr[2] != 0 && ipAddr[3] != 0) {
+                break;
+            }
+//            break;
+        }
+        delay(1000);
     }
 
-    bool LC7681Wifi::connect(IPAddress ip, int port, bool udp )
-    {
-      char buf[20];
-      String AT = String(ip[0])+"." +String(ip[1])+"." +String(ip[2])+"." +String(ip[3]);
-     // //Serial.println(ip[3]);
-      //AT.reserve(AT.length());
-      AT.toCharArray(buf, AT.length()+1);
+    return ipAddr;
+}
 
-        //sprintf(buf, "AT+WSW=%d,", m_lport);
-      
-     
-      //sprintf(buf, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
-      return connect(buf, port, udp);
+IPAddress LC7681Wifi::nslookup(const char* server)
+{
+    String cmd, result, ips;
+    IPAddress ipAddr;
+
+    cmd = F("AT+WDNL=");
+    cmd += server;
+
+    while(true) {
+        m_stream->println(cmd);
+        result = _wait_for("+WDNL:", 5);
+        if(result.length() != 0) {
+            ips = result.substring(result.lastIndexOf(',')+1);
+            ipAddr = s2ip(ips.c_str());
+            if(ipAddr[0] != 0 && ipAddr[1] != 0 && ipAddr[2] != 0 && ipAddr[3] != 0) {
+                break;
+            }
+        }
+        delay(1000);
     }
-    
-     bool LC7681Wifi::connect(const char* ip, int port, bool udp )
-  {
+
+    return ipAddr;
+}
+
+bool LC7681Wifi::connect(IPAddress ip, int port, bool udp )
+{
+    char buf[20];
+    String AT = String(ip[0])+"." +String(ip[1])+"." +String(ip[2])+"." +String(ip[3]);
+    // //Serial.println(ip[3]);
+    //AT.reserve(AT.length());
+    AT.toCharArray(buf, AT.length()+1);
+
+    //sprintf(buf, "AT+WSW=%d,", m_lport);
+
+
+    //sprintf(buf, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
+    return connect(buf, port, udp);
+}
+
+bool LC7681Wifi::connect(const char* ip, int port, bool udp )
+{
     String str = "AT+WSO=";
     str += ip;
     str += ",";
@@ -269,51 +285,50 @@ static int base64_decode(const uint8_t* src, int len, uint8_t* dest)
     //Serial.println(str);
     str = _wait_for("+WSO:",30);
     if(str.length() == 0)
-      return false;
-    
+        return false;
+
     m_lport = str.substring(5).toInt();
     if(udp)
-      return true;
-      
+        return true;
+
     str = "+WSS:";
     str += m_lport;
     str = _wait_for(str.c_str(),30);
-    //
     if(str.length() == 0)
     {
-     
-      m_lport = 0;
-      return false;
+
+        m_lport = 0;
+        return false;
     }
     str.remove(0,str.lastIndexOf(',')+1);
 
-    
+
     if(str.toInt() == 0)
     {
-     
-      
-      m_lport = 0;
-      return false;
+
+
+        m_lport = 0;
+        return false;
     }
 
     return true;
-  }
-
-  int LC7681Wifi::freeRam () 
-{
-  extern int __heap_start, *__brkval; 
-  int v; 
-  return (int) &v - (__brkval == 0 ? (int) &__heap_start : (int) __brkval); 
 }
-    bool LC7681Wifi::print(const char* data, int dataLen)
+
+int LC7681Wifi::freeRam () 
+{
+    extern int __heap_start, *__brkval; 
+    int v; 
+    return (int) &v - (__brkval == 0 ? (int) &__heap_start : (int) __brkval); 
+}
+bool LC7681Wifi::print(const char* data, int dataLen)
+{
+    char buf[100];
+    const char *src = data;
+    char *dest = buf;
+    int remain = dataLen;
+
+    while(remain > 0)
     {
-      char buf[100];
-      const char *src = data;
-      char *dest = buf;
-      int remain = dataLen;
-      
-      while(remain > 0)
-      {
         int part = remain > 48 ? 48 : remain;
 
         String AT = F("AT+WSW=");
@@ -334,157 +349,171 @@ static int base64_decode(const uint8_t* src, int len, uint8_t* dest)
         String str = _wait_for("+WSDS:",30);
         int count = 0;
         while(str.length() == 0){
-          count++;
-          m_stream->print(buf);
-          str = _wait_for("+WSDS:",30);
-          if (count>3)
-          {
-            return false;/* code */
-          }
+            count++;
+            m_stream->print(buf);
+            str = _wait_for("+WSDS:",30);
+            if (count>3)
+            {
+                return false;/* code */
+            }
         }
-       
-      }    
-      return true;
-    }
-    
-    bool LC7681Wifi::print(const char* data )
-    {
-      if(!data)
-      return false;
-      
-      return print(data, strlen(data));
-    }
 
-    bool LC7681Wifi::println(const char* data)
-    {
-      String str;
-      if(data)
-      str = data;
-      str += "\r\n";
-      
-      return print(str.c_str());
+    }    
+    return true;
+}
+
+bool LC7681Wifi::print(const char* data )
+{
+    if(!data)
+        return false;
+
+    return print(data, strlen(data));
+}
+
+bool LC7681Wifi::println(const char* data)
+{
+    String str;
+    if(data)
+        str = data;
+    str += "\r\n";
+
+    return print(str.c_str());
+}
+
+bool LC7681Wifi::listenTo(uint16_t port, bool udp) {
+    String str = "AT+WSL=";
+    str += port;
+    str += ",";
+    str += udp ? "1" : "0";
+    m_stream->println(str);
+    str = _wait_for("OK",5);
+    if(str.length() == 0) {
+        m_lport = 0;
+        return false;
     }
-    
-    void LC7681Wifi::process(LC7681WifiCallback cb)
+    else {
+        m_lport = port;
+        return true;
+    }
+        
+}
+
+void LC7681Wifi::process(LC7681WifiCallback cb)
+{
+    int c;
+    while(m_stream->available())
     {
-      int c;
-      while(m_stream->available())
-      {
         c = m_stream->read();
+//        Serial.write(c); //debug use
         m_buffer[m_bufferPos] = (char)c;
         m_bufferPos++;
         if(c == '\n')
         {
-          m_buffer[m_bufferPos] = 0;
-          m_bufferPos = 0;
-          
-          if(m_log)
-          {
-            m_log->print(F("[log]"));
-            m_log->println(m_buffer);
-          }
+            m_buffer[m_bufferPos] = 0;
+            m_bufferPos = 0;
 
-          if(!strncmp(m_buffer, "+WSDR:", 6))
-          {
-            String s = m_buffer+6;
-            s.trim();
-            int t1 = s.indexOf(',');
-            int t2 = s.indexOf(',', t1+1);
-            int port = s.substring(0, t1).toInt();
-            
-            if(port == m_lport)
+            if(m_log)
             {
-              int len = s.substring(t1+1, t2).toInt();
-              String data = s.substring(t2+1);
-              if(m_log && data.length() != len)
-              {
-                m_log->print("[Warning] length not matching:");
-                m_log->println(len);
-                m_log->println(data.length());
-                m_log->println(data);
-
-              }
-            
-           else{
-            // use m_buffer as temp buffer
-            t1 = base64_decode((const uint8_t*)data.c_str(), len, (uint8_t*)m_buffer);
-            m_buffer[t1] = 0;
-            cb(EVENT_DATA_RECEIVED, (uint8_t*)m_buffer, t1);
-          }
-          }
-        }
-        else if(!strncmp(m_buffer, "+WSS:", 5))
-        {
-          String s = m_buffer+5;
-          s.trim();
-          int t1 = s.indexOf(',');
-          int port = s.substring(0, t1).toInt();
-          int state = s.substring(t1+1).toInt();
-          if(port == m_lport)
-          {
-            if(state == 0)
-            cb(EVENT_SOCKET_DISCONNECT, NULL, 0);
-            m_lport = 0;
-          }
-        }
-       /* else if(!strncmp(m_buffer, "+WCAP:", 6))
-        {
-            String s = m_buffer+6;
-            if(s.substring(7)==""){
-            cb(EVENT_AP_DISCONNECT, NULL, 0);
-
+                m_log->print(F("[log]"));
+                m_log->println(m_buffer);
             }
 
-            
-            
-          
+            if(!strncmp(m_buffer, "+WSDR:", 6))
+            {
+               
+                String s = m_buffer+6;
+                s.trim();
+                int t1 = s.indexOf(',');
+                int t2 = s.indexOf(',', t1+1);
+                int port = s.substring(0, t1).toInt();
+                
+//                Serial.print("raw data:");
+//                Serial.println(s);
+//                Serial.print("port:");
+//                Serial.println(port);
+//                Serial.print("listen port:");
+//                Serial.println(m_lport);
+                
+                if(port == m_lport)
+                {
+                    int len = s.substring(t1+1, t2).toInt();
+                    String data = s.substring(t2+1);
+//                    Serial.print("content:");
+//                    Serial.println(data);
+//                    Serial.print("len:");
+//                    Serial.println(data.length());
+                    
+                    if(m_log && data.length() != len)
+                    {
+                        m_log->print("[Warning] length not matching:");
+                        m_log->println(len);
+                        m_log->println(data.length());
+                        m_log->println(data);
+                    }
+                    else{
+                        // use m_buffer as temp buffer
+                        t1 = base64_decode((const uint8_t*)data.c_str(), len, (uint8_t*)m_buffer);
+                        m_buffer[t1] = 0;
+                        cb(EVENT_DATA_RECEIVED, (uint8_t*)m_buffer, t1);
+                    }
+                }
+            }
+            else if(!strncmp(m_buffer, "+WSS:", 5))
+            {
+                String s = m_buffer+5;
+                s.trim();
+                int t1 = s.indexOf(',');
+                int port = s.substring(0, t1).toInt();
+                int state = s.substring(t1+1).toInt();
+                if(port == m_lport)
+                {
+                    if(state == 0) {
+                        cb(EVENT_SOCKET_DISCONNECT, NULL, 0);
+                        m_lport = 0;
+                    }
+                }
+            }
         }
-        */
-      }
     }
-  }
-  
-   String LC7681Wifi::_wait_for(const char* pattern,  uint32_t  timeout)
-  {
+}
+
+String LC7681Wifi::_wait_for(const char* pattern,  uint32_t  timeout)
+{
     unsigned long _timeout = millis() + timeout*1000;
     char buf[128];
     int i, c;
-    //Serial.println(_timeout);
-    //Serial.println(millis());
-    //Serial.println(timeout);
     if(m_log)
-      m_log->println("[wait_for]");
-    
+        m_log->println("[wait_for]");
+
     i = 0;
     while(millis() <= _timeout)
     {
-  
-      while(m_stream->available())
-      {
-        c = m_stream->read();
-        if(m_log)
-          m_log->write(c);
-        
-        buf[i] = (char)c;
-        i++;
-        if (i>100)  //prevent overflow
+
+        while(m_stream->available())
         {
-          i=0;
+            c = m_stream->read();
+            if(m_log)
+                m_log->write(c);
+
+            buf[i] = (char)c;
+            i++;
+            if (i>100)  //prevent overflow
+            {
+                i=0;
+            }
+            if(c == '\n')
+            {
+                buf[i] = 0;    
+                if(0 == strncmp(buf, pattern, strlen(pattern)))
+                {
+                    String result(buf);
+                    result.trim();
+                    return result;
+                }
+
+                i = 0;
+            }
         }
-        if(c == '\n')
-        {
-          buf[i] = 0;
-          
-          if(0 == strncmp(buf, pattern, strlen(pattern)))
-          {
-            String result(buf);
-            result.trim();
-            return result;
-          }
-          
-          i = 0;
-        }
-      }
-    }
+    }  
     return String(""); // timeout
-  }
+}

--- a/Arduino_sample/MT7681/MT7681.h
+++ b/Arduino_sample/MT7681/MT7681.h
@@ -26,16 +26,18 @@ public:
   bool print(const char* data, int dataLen);
   bool print(const char* data = NULL);
   bool println(const char* data = NULL);
+  bool listenTo(uint16_t port, bool udp);
   void process(LC7681WifiCallback cb);
 
+  Stream *m_stream;
 private:
   String _wait_for(const char* pattern,uint32_t timeout = 300);
   int freeRam();
 private: 
-  Stream *m_stream;
+  
   Stream *m_log;
   
-  int m_lport;
+  uint16_t m_lport;
   int m_bufferPos;
   char m_buffer[70];
 };

--- a/Arduino_sample/MT7681/examples/test_connect_with7681/test_connect_with7681.ino
+++ b/Arduino_sample/MT7681/examples/test_connect_with7681/test_connect_with7681.ino
@@ -1,0 +1,119 @@
+#include "MT7681.h"
+
+#define wifiSerial Serial1
+LC7681Wifi wifi(&wifiSerial);
+                    
+const char ssid[] = "Lab430 2.4GHz";
+const char key[] = "";
+const char server[] = "www.arduino.cc";
+const int port = 80;
+
+
+int RST = 13;
+void setup() {
+   pinMode(RST, OUTPUT);
+   digitalWrite(RST, HIGH);
+  Serial.begin(115200);
+  wifiSerial.begin(115200);
+  while(!Serial || !wifiSerial)
+    delay(100);
+
+  // reset module
+  Serial.print("[log] Resetting Module...");
+  digitalWrite(RST, LOW);
+  delay(1000);
+  digitalWrite(RST, HIGH);
+  while(1){
+//    Serial.println("Go!!");
+    if(wifiSerial.available()){
+    char c = wifiSerial.read(); 
+//    Serial.write(c);
+    if(c=='<'){
+       break;
+      }
+    }
+  }
+  delay(1000);
+  Serial.println("done");
+  
+  wifi.begin();
+  
+  // attempt to connect to AP
+  while(true)
+  {
+    Serial.println("[log] Trying to connect AP...");
+    if(!wifi.connectAP(ssid, key))
+    {
+      Serial.println("[log] Fail to connect, wait 5 secs to retry...");
+      delay(5000);
+      continue;
+    }
+
+    Serial.println("[log] Connected to AP!");
+    break;
+  }
+
+  // print status
+  delay(1000);
+  Serial.print("[log] IP Address: ");
+  Serial.println(wifi.IP());
+
+  // lookup server ip
+  IPAddress serverIp;
+  serverIp = wifi.nslookup(server);
+  Serial.print("[log] IP Address of ");
+  Serial.print(server);
+  Serial.print(" is ");
+  Serial.println(serverIp);
+  
+  // connect to server
+  while(true)
+  {
+    Serial.println("[log] Trying to start connection to server...");
+    if (!wifi.connect(serverIp, port))
+    {
+      Serial.println("[log] Fail to connected to server, wait 5 secs to retry...");
+      delay(5000);
+      continue;
+    }
+    
+    Serial.println("[log] Connected to server!");
+    break;
+  }
+  
+//  Serial.println("[log] Send HTTP request");
+//  // Make a HTTP request:
+//  wifi.println("GET /asciilogo.txt HTTP/1.1");
+//  wifi.println("Host: www.arduino.cc");
+//  //wifi.println("Connection: close");
+//  wifi.println();
+
+  Serial.println("try to listen to port 8000");
+  if(wifi.listenTo(8000,false)) {
+    Serial.println("succeed to listen to 8000");
+  }
+  else {
+    Serial.println("failed to listen to 8000");
+  }
+
+}
+
+void callback(int event, const uint8_t* data, int dataLen)
+{
+  switch(event)
+  {
+  case LC7681Wifi::EVENT_DATA_RECEIVED:
+    Serial.print("data received:");
+    Serial.println((const char*)data);
+    break;
+  case LC7681Wifi::EVENT_SOCKET_DISCONNECT:
+    Serial.println("[log] Connection to server is closed!");
+    break;
+  }
+}
+
+void loop() 
+{ 
+  wifi.process(callback);
+}
+


### PR DESCRIPTION
I have found that Ip and nslookup would return false ip like 0.0.0.0 sometimes.
And the condition of "+WSS:" in process function, only if the state equals 0, m_lport needs to be set to 0.
above these bugs, I have fixed them in my forked version. 
